### PR TITLE
优化+修复流程管理导出错误

### DIFF
--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/workflow/WfFormController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/workflow/WfFormController.java
@@ -53,7 +53,7 @@ public class WfFormController extends BaseController {
      */
     @SaCheckPermission("workflow:form:export")
     @Log(title = "流程表单", businessType = BusinessType.EXPORT)
-    @GetMapping("/export")
+    @PostMapping("/export")
     public void export(@Validated WfFormBo bo, HttpServletResponse response) {
         List<WfFormVo> list = formService.queryList(bo);
         ExcelUtil.exportExcel(list, "流程表单", WfFormVo.class, response);

--- a/ruoyi-ui/src/api/workflow/form.js
+++ b/ruoyi-ui/src/api/workflow/form.js
@@ -50,12 +50,3 @@ export function delForm(formId) {
     method: 'delete'
   })
 }
-
-// 导出流程表单
-export function exportForm(query) {
-  return request({
-    url: '/workflow/form/export',
-    method: 'get',
-    params: query
-  })
-}

--- a/ruoyi-ui/src/views/workflow/category/index.vue
+++ b/ruoyi-ui/src/views/workflow/category/index.vue
@@ -287,7 +287,7 @@ export default {
     },
     /** 导出按钮操作 */
     handleExport() {
-      this.download('system/category/export', {
+      this.download('workflow/category/export', {
         ...this.queryParams
       }, `category_${new Date().getTime()}.xlsx`)
     }

--- a/ruoyi-ui/src/views/workflow/form/index.vue
+++ b/ruoyi-ui/src/views/workflow/form/index.vue
@@ -130,7 +130,7 @@
 </template>
 
 <script>
-import { listForm, getForm, delForm, addForm, updateForm, exportForm } from "@/api/workflow/form";
+import { listForm, getForm, delForm, addForm, updateForm } from "@/api/workflow/form";
 import Editor from '@/components/Editor';
 import Parser from '@/utils/generator/parser'
 export default {
@@ -287,15 +287,15 @@ export default {
     },
     /** 导出按钮操作 */
     handleExport() {
-      const queryParams = this.queryParams;
+      let _this = this
       this.$confirm('是否确认导出所有流程表单数据项?', "警告", {
         confirmButtonText: "确定",
         cancelButtonText: "取消",
         type: "warning"
       }).then(function() {
-        return exportForm(queryParams);
-      }).then(response => {
-        this.download(response.msg);
+        _this.download('/workflow/form/export', {
+        ..._this.queryParams
+      }, `form_${new Date().getTime()}.xlsx`)
       })
     }
   }

--- a/ruoyi-ui/src/views/workflow/form/index.vue
+++ b/ruoyi-ui/src/views/workflow/form/index.vue
@@ -176,6 +176,9 @@ export default {
       }
     };
   },
+  created() {
+    this.getList();
+  },
   activated() {
     this.getList();
   },

--- a/ruoyi-ui/src/views/workflow/work/claim.vue
+++ b/ruoyi-ui/src/views/workflow/work/claim.vue
@@ -101,6 +101,9 @@ export default {
       rules: {}
     };
   },
+  created() {
+    this.getList();
+  },
   activated() {
     this.getList();
   },

--- a/ruoyi-ui/src/views/workflow/work/detail.vue
+++ b/ruoyi-ui/src/views/workflow/work/detail.vue
@@ -302,19 +302,25 @@ export default {
       userOpen: false
     };
   },
+  created() {
+    this.init();
+  },
   activated() {
-    this.taskForm.deployId = this.$route.query && this.$route.query.deployId;
-    this.taskForm.definitionId = this.$route.query && this.$route.query.definitionId;
-    this.taskForm.taskId  = this.$route.query && this.$route.query.taskId;
-    this.taskForm.procInsId = this.$route.query && this.$route.query.procInsId;
-    this.finished =  this.$route.query && this.$route.query.finished
-    // 流程任务重获取变量表单
-    if (this.taskForm.taskId) {
-      this.getProcessDetails(this.taskForm.procInsId, this.taskForm.deployId, this.taskForm.taskId);
-    }
-    this.loadIndex = this.taskForm.procInsId;
+    this.init();
   },
   methods: {
+    init() {
+      this.taskForm.deployId = this.$route.query && this.$route.query.deployId;
+      this.taskForm.definitionId = this.$route.query && this.$route.query.definitionId;
+      this.taskForm.taskId  = this.$route.query && this.$route.query.taskId;
+      this.taskForm.procInsId = this.$route.query && this.$route.query.procInsId;
+      this.finished =  this.$route.query && this.$route.query.finished
+      // 流程任务重获取变量表单
+      if (this.taskForm.taskId) {
+        this.getProcessDetails(this.taskForm.procInsId, this.taskForm.deployId, this.taskForm.taskId);
+      }
+      this.loadIndex = this.taskForm.procInsId;
+    },
     /** 查询部门下拉树结构 */
     getTreeSelect() {
       deptTreeSelect().then(response => {

--- a/ruoyi-ui/src/views/workflow/work/detail.vue
+++ b/ruoyi-ui/src/views/workflow/work/detail.vue
@@ -60,7 +60,7 @@
 
       <el-tab-pane label="表单信息" name="form">
         <div v-if="formOpen">
-          <el-card class="box-card" shadow="never" v-for="formInfo in processFormList">
+          <el-card class="box-card" shadow="never" v-for="(formInfo, index) in processFormList" :key="index">
             <div slot="header" class="clearfix">
               <span>{{ formInfo.title }}</span>
             </div>
@@ -90,12 +90,14 @@
                       <el-descriptions-item label="办结时间">{{ item.endTime || '-' }}</el-descriptions-item>
                       <el-descriptions-item label="耗时">{{ item.duration || '-'}}</el-descriptions-item>
                     </el-descriptions>
-                    <div v-if="item.commentList && item.commentList.length > 0" v-for="comment in item.commentList">
-                      <el-divider content-position="left">
-                        <el-tag :type="approveTypeTag(comment.type)" size="mini">{{ commentType(comment.type) }}</el-tag>
-                        <el-tag type="info" effect="plain" size="mini">{{ comment.time }}</el-tag>
-                      </el-divider>
-                      <span>{{ comment.fullMessage }}</span>
+                    <div v-if="item.commentList && item.commentList.length > 0">
+                      <div v-for="(comment, index) in item.commentList" :key="index">
+                        <el-divider content-position="left">
+                          <el-tag :type="approveTypeTag(comment.type)" size="mini">{{ commentType(comment.type) }}</el-tag>
+                          <el-tag type="info" effect="plain" size="mini">{{ comment.time }}</el-tag>
+                        </el-divider>
+                        <span>{{ comment.fullMessage }}</span>
+                      </div>
                     </div>
                   </el-card>
                   <el-card v-if="item.activityType === 'endEvent'" class="box-card" shadow="hover">

--- a/ruoyi-ui/src/views/workflow/work/finished.vue
+++ b/ruoyi-ui/src/views/workflow/work/finished.vue
@@ -133,6 +133,9 @@ export default {
       }
     };
   },
+  created() {
+    this.getList();
+  },
   activated() {
     this.getList();
   },

--- a/ruoyi-ui/src/views/workflow/work/finished.vue
+++ b/ruoyi-ui/src/views/workflow/work/finished.vue
@@ -222,7 +222,7 @@ export default {
     /** 撤回任务 */
     handleRevoke(row){
       const params = {
-        instanceId: row.procInsId
+        procInsId: row.procInsId
       }
       revokeProcess(params).then( res => {
         this.$modal.msgSuccess(res.msg);

--- a/ruoyi-ui/src/views/workflow/work/own.vue
+++ b/ruoyi-ui/src/views/workflow/work/own.vue
@@ -165,6 +165,7 @@ export default {
   },
   created() {
     this.getCategoryList();
+    this.getList();
   },
   activated() {
     this.getList();

--- a/ruoyi-ui/src/views/workflow/work/own.vue
+++ b/ruoyi-ui/src/views/workflow/work/own.vue
@@ -224,7 +224,7 @@ export default {
     /**  取消流程申请 */
     handleStop(row){
       const params = {
-        instanceId: row.procInsId
+        procInsId: row.procInsId
       }
       stopProcess(params).then( res => {
         this.$modal.msgSuccess(res.msg);

--- a/ruoyi-ui/src/views/workflow/work/todo.vue
+++ b/ruoyi-ui/src/views/workflow/work/todo.vue
@@ -122,6 +122,9 @@ export default {
       rules: {}
     };
   },
+  created() {
+    this.getList();
+  },
   activated() {
     this.getList();
   },


### PR DESCRIPTION
更改目的 解决了什么问题
1. 解决浏览器刷新表单配置列表一直转圈圈问题
2. 解决浏览器刷新流程详情页面不展示的问题
3. 解决流程详情页语法报错问题
4. 解决代办，已办，抄送和我的流程，浏览器刷新不展示问题
5. 解决流程分类，表单配置导出错误的问题

描述 做了哪些改动
增加页面的created周期，使浏览器刷新后能够展示列表或者详情数据
优化代码，将v-if与v-for不在同一标签内使用
流程分类导出前端接口有误，表单配置导出接口前端接收有误并且后端接收的http请求方法与前端不一致

测试 都做了哪些测试(未经过测试不采纳)
都已本地测试